### PR TITLE
Function properly when grep is set to color

### DIFF
--- a/cmd/brew-which-formula.rb
+++ b/cmd/brew-which-formula.rb
@@ -18,7 +18,7 @@ LIST_PATH = File.expand_path("#{File.dirname(__FILE__)}/../executables.txt")
 def matches(cmd)
   # We use 'grep' here to speed up our search
   # TODO: benchmark grep vs. reading the file line-by-line in Ruby
-  Utils.popen_read("grep", cmd, LIST_PATH).chomp.split(/\n/)
+  Utils.popen_read("grep", "--color=never", cmd, LIST_PATH).chomp.split(/\n/)
 end
 
 # Test if we have to reject the given formula, i.e. not suggest it.


### PR DESCRIPTION
I have grep set to highlight its output using the GREP_COLOR enviroment variable. Because brew-which-formula shells out to grep, the color output confuses it.

This pull request passes the --color=never option to grep, which solves the problem.

However, I'd recommend trying to get away from shelling out to grep if possible. There'll probably be a lot more headaches like this that are system-dependent and difficult to track down.