### PR TITLE
Don't return 127 when a recommendation was found

### DIFF
--- a/handler.sh
+++ b/handler.sh
@@ -33,11 +33,10 @@ homebrew_command_not_found_handle() {
     if [ -z "$txt" ]; then
         [ -n "$BASH_VERSION" ] && \
             TEXTDOMAIN=command-not-found echo $"$cmd: command not found"
+        return 127
     else
         echo "$txt"
     fi
-
-    return 127
 }
 
 if [ -n "$BASH_VERSION" ]; then


### PR DESCRIPTION
zsh (not sure about bash) adds an extra <samp>zsh: command not found: \<command></samp>
message if `command_not_found_handler()` returns <samp>127</samp>:

<pre><samp>~ $ when
The program 'when' is currently not installed. You can install it by typing:
  brew install when
zsh: command not found: when</samp></pre>

This pull request changes `homebrew_command_not_found_handle()` to only return
<samp>127</samp> if there was no formula recommendation found for the command the user
typed:

<pre><samp>~ $ when
The program 'when' is currently not installed. You can install it by typing:
  brew install when
~ $ sldkfjsldkfj
zsh: command not found: sldkfjsldkfj</samp></pre>

This appears to me to be the correct behaviour.