### PR TITLE
Add error message for zsh

### DIFF
--- a/handler.sh
+++ b/handler.sh
@@ -23,6 +23,8 @@ homebrew_command_not_found_handle() {
     if test -z "$CONTINUOUS_INTEGRATION" && test -n "$MC_SID" -o ! -t 1 ; then
         [ -n "$BASH_VERSION" ] && \
             TEXTDOMAIN=command-not-found echo $"$cmd: command not found"
+        [ -n "$ZSH_VERSION" ] && \
+            echo $"command not found: $cmd" >&2
         return 127
     fi
 
@@ -33,6 +35,8 @@ homebrew_command_not_found_handle() {
     if [ -z "$txt" ]; then
         [ -n "$BASH_VERSION" ] && \
             TEXTDOMAIN=command-not-found echo $"$cmd: command not found"
+        [ -n "$ZSH_VERSION" ] && \
+            echo "zsh: command not found: $cmd" >&2
     else
         echo "$txt"
     fi


### PR DESCRIPTION
According to http://zsh.sourceforge.net/Doc/Release/Command-Execution.html

It's not clear if zsh used to print the error itself, like https://bugzilla.redhat.com/show_bug.cgi?id=1358372 seems to suggest, but the latest version of zsh doesn't, and is documented as such.