### PR TITLE
README: Remove outdated Bash upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,9 @@ brew tap homebrew/command-not-found
 
 This tool requires one of the following:
 
+* [Zsh](https://www.zsh.org) (the default on macOS Catalina and above)
 * [Bash](https://www.gnu.org/software/bash/) (version 4 and higher)
 * [Fish](https://fishshell.com)
-* [Zsh](https://www.zsh.org)
-
-macOS ships Bash 3.x so you must upgrade to v4.x and configure it to be used with:
-
-```bash
-brew update && brew install bash
-# Add the new shell to the list of allowed shells
-sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
-# Change to the new shell
-chsh -s /usr/local/bin/bash
-```
 
 ## How it works
 

--- a/cmd/which-formula.rb
+++ b/cmd/which-formula.rb
@@ -22,7 +22,7 @@ module Homebrew
   def which_formula
     args = which_formula_args.parse
 
-    # Note: It probably doesn't make sense to use that on multiple commands since
+    # NOTE: It probably doesn't make sense to use that on multiple commands since
     # each one might print multiple formulae
     args.named.each do |command|
       Homebrew::WhichFormula.which_formula command, explain: args.explain?

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -49,7 +49,7 @@ module Homebrew
 
         name = f.full_name
 
-        # note: f.installed? is true only if the *latest* version is installed.
+        # NOTE: f.installed? is true only if the *latest* version is installed.
         # We thus don't need to worry about updating outdated versions
         if f.latest_version_installed?
           update_installed_formula f


### PR DESCRIPTION
- The most recent two macOS versions have Zsh as their default shell.
