### PR TITLE
Rakefile: remove environment.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ namespace :test do
   include Test::Unit::Assertions
 
   [:bash, :zsh].each do |sh|
-    task sh => :environment do
+    task sh do
       puts "Testing with #{sh}"
       command = "eval \"$(brew command-not-found-init)\"; when"
       # -e: exit on first error
@@ -24,7 +24,7 @@ namespace :test do
     end
   end
 
-  task fish: :environment do
+  task :fish do
     puts "Testing with fish"
     # use `emit fish_prompt` to simulate interactive shell
     command = ". (brew command-not-found-init); emit fish_prompt; when"


### PR DESCRIPTION
Incorrectly added by `brew style` (fixed in https://github.com/Homebrew/brew/pull/10469).