### PR TITLE
Update which-update.rb

### DIFF
--- a/cmd/which-formula.rb
+++ b/cmd/which-formula.rb
@@ -8,14 +8,12 @@ module Homebrew
 
   def which_formula_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `which-formula` <command>
-
+      description <<~EOS
         Prints the formula(e) which provides the given command.
       EOS
       switch "--explain",
              description: "Output explanation of how to get 'cmd' by installing one of the providing formulae."
-      min_named 1
+      named_args :database, min: 1
     end
   end
 

--- a/cmd/which-formula.rb
+++ b/cmd/which-formula.rb
@@ -13,7 +13,7 @@ module Homebrew
       EOS
       switch "--explain",
              description: "Output explanation of how to get 'cmd' by installing one of the providing formulae."
-      named_args :database, min: 1
+      named_args :command, min: 1
     end
   end
 

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -8,9 +8,7 @@ module Homebrew
 
   def which_update_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `which-update` [<database>]
-
+      description <<~EOS
         Database update for `brew-which-formula`
       EOS
       switch "--stats",
@@ -19,7 +17,7 @@ module Homebrew
       switch "--commit",
              description: "commit the changes using `git`."
       conflicts "--stats", "--commit"
-      named_args max: 1
+      named_args :database, max: 1
     end
   end
 

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -19,7 +19,7 @@ module Homebrew
       switch "--commit",
              description: "commit the changes using `git`."
       conflicts "--stats", "--commit"
-      max_named 1
+      named_args max: 1
     end
   end
 


### PR DESCRIPTION
```console
$ brew which-update
Warning: Calling `max_named` is deprecated! Use `named_args max:` instead.
Please report this issue to the homebrew/command-not-found tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/cmd/which-update.rb:22
```