### PR TITLE
Add scheduled workflow to update database

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Update database
         env:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-        run: brew which-update --commit --install-missing executables.txt
+        run: brew which-update --commit --update-existing --install-missing executables.txt
 
       - name: Output database stats
         run: brew which-update --stats executables.txt

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,35 @@
+name: Scheduled database updates
+on:
+  push:
+    paths:
+      - .github/workflows/scheduled.yml
+  schedule:
+    # Once every day at midnight UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  generate:
+    if: startsWith( github.repository, 'Homebrew/' )
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Update database
+        run: brew which-update --commit --install-missing executables.txt
+
+      - name: Output database stats
+        run: brew which-update --stats executables.txt
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -25,7 +25,14 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Update database
+        env:
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: brew which-update --commit --install-missing executables.txt
 
       - name: Output database stats

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -11,10 +11,7 @@ on:
 jobs:
   generate:
     if: startsWith( github.repository, 'Homebrew/' )
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macOS-latest, ubuntu-latest]
+    runs-on: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@main

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -9,14 +9,17 @@ module Homebrew
   def which_update_args
     Homebrew::CLI::Parser.new do
       description <<~EOS
-        Database update for `brew-which-formula`
+        Database update for `brew which-formula`
       EOS
       switch "--stats",
-             description: "print statistics about the database contents (number of commands and formulae, " \
+             description: "Print statistics about the database contents (number of commands and formulae, " \
                           "list of missing formulae)."
       switch "--commit",
-             description: "commit the changes using `git`."
+             description: "Commit the changes using `git`."
+      switch "--install-missing",
+             description: "Install and update formulae that are missing from the database and don't have bottles."
       conflicts "--stats", "--commit"
+      conflicts "--stats", "--install-missing"
       named_args :database, max: 1
     end
   end
@@ -27,7 +30,8 @@ module Homebrew
     if args.stats?
       Homebrew::WhichUpdate.stats source: args.named.first
     else
-      Homebrew::WhichUpdate.update_and_save! source: args.named.first, commit: args.commit?
+      Homebrew::WhichUpdate.update_and_save! source: args.named.first, commit: args.commit?,
+                                             install_missing: args.install_missing?
     end
   end
 end

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -16,10 +16,13 @@ module Homebrew
                           "list of missing formulae)."
       switch "--commit",
              description: "Commit the changes using `git`."
+      switch "--update-existing",
+             description: "Update database entries with outdated formula versions."
       switch "--install-missing",
              description: "Install and update formulae that are missing from the database and don't have bottles."
       conflicts "--stats", "--commit"
       conflicts "--stats", "--install-missing"
+      conflicts "--stats", "--update-existing"
       named_args :database, max: 1
     end
   end
@@ -31,6 +34,7 @@ module Homebrew
       Homebrew::WhichUpdate.stats source: args.named.first
     else
       Homebrew::WhichUpdate.update_and_save! source: args.named.first, commit: args.commit?,
+                                             update_existing: args.update_existing?,
                                              install_missing: args.install_missing?
     end
   end

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -62,7 +62,7 @@ module Homebrew
         # Install unbottled formulae if they should be added/updated
         if !f.bottled? && install_missing && update_formula
           ohai "Installing #{f}"
-          system HOMEBREW_BREW_FILE, "install", "--formula", f
+          system HOMEBREW_BREW_FILE, "install", "--formula", f.to_s
         end
 
         # We don't need to worry about updating outdated versions unless update_existing is true
@@ -122,7 +122,7 @@ module Homebrew
 
     def outdated_formula?(formula)
       current_version = @exes[formula.full_name][0]
-      formula.pkg_version != current_version
+      formula.pkg_version.to_s != current_version
     end
 
     def update_formula_binaries_from_prefix(formula, prefix = nil)

--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -61,6 +61,10 @@ module Homebrew
 
       return if formulae.blank?
 
+      formulae.map! do |formula|
+        formula.sub(/\(.*\)$/, "")
+      end
+
       if explain
         explain_formulae_install(cmd, formulae)
       else

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -43,19 +43,10 @@ module Homebrew
       nil
     end
 
-    def update_and_save!(source: nil, commit: false, install_missing: false)
+    def update_and_save!(source: nil, commit: false, update_existing: false, install_missing: false)
       source ||= default_source
       db = ExecutablesDB.new source
-      db.update!
-
-      if install_missing
-        (Formula.core_names - db.formula_names).each do |formula|
-          ohai "Installing #{formula}"
-          system HOMEBREW_BREW_FILE, "install", "--formula", formula
-        end
-        db.update!
-      end
-
+      db.update!(update_existing: update_existing, install_missing: install_missing)
       db.save!
       return if !commit || !db.changed?
 

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -43,10 +43,19 @@ module Homebrew
       nil
     end
 
-    def update_and_save!(source: nil, commit: false)
+    def update_and_save!(source: nil, commit: false, install_missing: false)
       source ||= default_source
       db = ExecutablesDB.new source
       db.update!
+
+      if install_missing
+        (Formula.core_names - db.formula_names).each do |formula|
+          ohai "Installing #{formula}"
+          system HOMEBREW_BREW_FILE, "install", "--formula", formula
+        end
+        db.update!
+      end
+
       db.save!
       return if !commit || !db.changed?
 

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -62,10 +62,11 @@ module Homebrew
 
     def git_commit_message(changes)
       msg = []
-      [:add, :update, :remove].each do |action|
+      [:add, :update, :remove, :version_bump].each do |action|
         names = changes[action]
         next if names.empty?
 
+        action = "bump version for" if action == :version_bump
         msg << english_list(names.to_a.sort, action.to_s)
         break
       end


### PR DESCRIPTION
This PR attempts to create a scheduled workflow to update the database using `brew which-update`.

It adds a new `--install-missing` option to `which-update` which will install missing formulae (i.e. those that are `bottle :unneeded`) that wouldn't otherwise be updated.

For now, I decided to run this on both macOS and Linux, each time once a day. It's probably overkill to run it on each but some formulae that are only available on one platform would otherwise be missed.

Edit: I realized that we probably don't want two jobs doing mostly the same thing running at the same time because they will both changes. For now, I changed to only run on macOS. I think this will cover most cases and, as always, specific linux-only instances can be managed manually if needed. If automating on Linux is still desired, let me know and we can brainstorm how to solve the problem.

I also set up the commit signing to that these commits are signed by BrewTestBot.

See https://github.com/Homebrew/brew/pull/11137
