### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       id: set-up-homebrew
       uses: Homebrew/actions/setup-homebrew@master
 
-    - run: brew style $GITHUB_REPOSITORY
+    - run: brew style homebrew/command-not-found
 
     - run: brew install bash fish
 

--- a/handler.fish
+++ b/handler.fish
@@ -2,7 +2,7 @@ function __fish_command_not_found_on_interactive --on-event fish_prompt
     functions --erase __fish_command_not_found_handler
     functions --erase __fish_command_not_found_setup
 
-    function __fish_command_not_found_handler --on-event fish_command_not_found
+    function fish_command_not_found
         set -l cmd $argv[1]
         set -l txt (brew which-formula --explain $cmd ^ /dev/null)
 
@@ -14,6 +14,10 @@ function __fish_command_not_found_on_interactive --on-event fish_prompt
                 echo $var
             end
         end
+    end
+
+    function __fish_command_not_found_handler --on-event fish_command_not_found
+        fish_command_not_found $argv
     end
 
     functions --erase __fish_command_not_found_on_interactive

--- a/handler.fish
+++ b/handler.fish
@@ -4,7 +4,7 @@ function __fish_command_not_found_on_interactive --on-event fish_prompt
 
     function fish_command_not_found
         set -l cmd $argv[1]
-        set -l txt (brew which-formula --explain $cmd ^ /dev/null)
+        set -l txt (brew which-formula --explain $cmd 2> /dev/null)
 
         if test -z "$txt"
             __fish_default_command_not_found_handler $cmd
@@ -22,4 +22,3 @@ function __fish_command_not_found_on_interactive --on-event fish_prompt
 
     functions --erase __fish_command_not_found_on_interactive
 end
-


### PR DESCRIPTION
This PR attempts to fix the broken CI. I think the issue has to do with fish command-not-found handler changing in version 3.2.0.

Now, there's a `fish_command_not_found` function that is called when a command isn't found. We can support both this new method and the old method by defining the existing handler as the `fish_command_not_found` function. Then, the old `__fish_command_not_found_handler` can be defined as a wrapper for the `fish_command_not_found` function.

I found all of this out from the commit message of https://github.com/fish-shell/fish-shell/commit/340de731726701d992ee4ec915dc41bdaf9d728c and played around with the different options until it worked locally.
