### PR TITLE
Fix automatic database updates

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -7,6 +7,10 @@ on:
     # Once every day at midnight UTC
     - cron: "0 0 * * *"
   workflow_dispatch:
+    inputs:
+      max-downloads:
+        description: Maximum number of formulae to download when updating
+        required: false
 
 jobs:
   update-database:
@@ -30,7 +34,12 @@ jobs:
       - name: Update database
         env:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-        run: brew which-update --commit --update-existing --install-missing executables.txt
+        run: |
+          if [[ -n "${{ github.event.inputs.max-downloads }}" ]]
+          then
+            MAX_DOWNLOADS_ARGS="--max-downloads ${{ github.event.inputs.max-downloads }}"
+          fi
+          brew which-update --commit --update-existing --install-missing $MAX_DOWNLOADS_ARGS executables.txt
 
       - name: Output database stats
         run: brew which-update --stats executables.txt

--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -2,14 +2,14 @@ name: Scheduled database updates
 on:
   push:
     paths:
-      - .github/workflows/scheduled.yml
+      - .github/workflows/update-database.yml
   schedule:
     # Once every day at midnight UTC
     - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
-  generate:
+  update-database:
     if: startsWith( github.repository, 'Homebrew/' )
     runs-on: macos-latest
     steps:

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -20,9 +20,12 @@ module Homebrew
              description: "Update database entries with outdated formula versions."
       switch "--install-missing",
              description: "Install and update formulae that are missing from the database and don't have bottles."
+      flag   "--max-downloads=",
+             description: "Specify a maximum number of formulae to download and update."
       conflicts "--stats", "--commit"
       conflicts "--stats", "--install-missing"
       conflicts "--stats", "--update-existing"
+      conflicts "--stats", "--max-downloads"
       named_args :database, max: 1
     end
   end
@@ -35,7 +38,8 @@ module Homebrew
     else
       Homebrew::WhichUpdate.update_and_save! source: args.named.first, commit: args.commit?,
                                              update_existing: args.update_existing?,
-                                             install_missing: args.install_missing?
+                                             install_missing: args.install_missing?,
+                                             max_downloads: args.max_downloads
     end
   end
 end

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -51,8 +51,11 @@ module Homebrew
 
     # update the DB with the installed formulae
     # @see #save!
-    def update!(update_existing: false, install_missing: false)
+    def update!(update_existing: false, install_missing: false, max_downloads: nil)
+      downloads = 0
+      opoo max_downloads
       Formula.each do |f|
+        break if max_downloads.present? && downloads > max_downloads.to_i
         next if f.tap?
 
         name = f.full_name
@@ -61,6 +64,7 @@ module Homebrew
 
         # Install unbottled formulae if they should be added/updated
         if !f.bottled? && install_missing && update_formula
+          downloads += 1
           ohai "Installing #{f}"
           system HOMEBREW_BREW_FILE, "install", "--formula", f.to_s
         end
@@ -69,6 +73,7 @@ module Homebrew
         if f.latest_version_installed?
           update_installed_formula f
         elsif f.bottled? && update_formula
+          downloads += 1
           update_bottled_formula f
         end
 

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -43,10 +43,11 @@ module Homebrew
       nil
     end
 
-    def update_and_save!(source: nil, commit: false, update_existing: false, install_missing: false)
+    def update_and_save!(source: nil, commit: false, update_existing: false, install_missing: false,
+                         max_downloads: nil)
       source ||= default_source
       db = ExecutablesDB.new source
-      db.update!(update_existing: update_existing, install_missing: install_missing)
+      db.update!(update_existing: update_existing, install_missing: install_missing, max_downloads: max_downloads)
       db.save!
       return if !commit || !db.changed?
 


### PR DESCRIPTION
Rename the workflow to better explain what it's doing. Also, add a `--max-downloads` flag to `which-update` so that the number of formulae updated per-run can be limited for manual invocations.
