### PR TITLE
Fix database update workflow and allow linux runs

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -11,11 +11,15 @@ on:
       max-downloads:
         description: Maximum number of formulae to download when updating
         required: false
+      runs-on:
+        description: GitHub actions runner to use when updating the database
+        required: true
+        default: macos-latest
 
 jobs:
   update-database:
     if: startsWith( github.repository, 'Homebrew/' )
-    runs-on: macos-latest
+    runs-on: ${{ github.event.inputs.runs-on || 'macos-latest' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@main

--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -1,6 +1,8 @@
 name: Scheduled database updates
 on:
   push:
+    branches:
+      - master
     paths:
       - .github/workflows/update-database.yml
   schedule:

--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 0
+          ref: master
 
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
This tries to fix the issue with PRs from #79. There, the workflow would be run from the non-`master` PR branch. Part of this run would checkout that branch, commit the changes, and then push to master. This meant that the PR commits were pushed directly, causing a fast-forward merge. This is undesirable. Now, the changes will be applied only to the master branch so the push doesn't include any PR commits.

While modifying that file, I also added the ability to use Linux to run the workflow if desired. This will not happen by default, but could be manually done.
