### PR TITLE
lib/executables.db: check bottle's sbin directory for executables

### DIFF
--- a/executables.txt
+++ b/executables.txt
@@ -3297,7 +3297,7 @@ moreutils(0.65):chronic combine errno ifdata ifne isutf8 lckdo mispipe parallel 
 morse(2.5_2):QSO morse
 mosh(1.3.2_15):mosh mosh-client mosh-server
 mosml(2.10.1):camlrunm mosml mosmlc mosmllex mosmlyac
-mosquitto(2.0.10_1):mosquitto_ctrl mosquitto_passwd mosquitto_pub mosquitto_rr mosquitto_sub
+mosquitto(2.0.10_1):mosquitto mosquitto_ctrl mosquitto_passwd mosquitto_pub mosquitto_rr mosquitto_sub
 most(5.1.0):most
 moto(2.0.5):moto_server
 movgrab(3.1.2_2):movgrab

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -166,7 +166,7 @@ module Homebrew
     def update_bottled_formula(formula)
       formula.bottle.fetch
       path = formula.bottle.resource.cached_download.to_s
-      content = Utils.popen_read("tar", "tzvf", path, "*/bin/*")
+      content = Utils.popen_read("tar", "tzvf", path, "*/bin/*", "*/sbin/*")
       binaries = []
       prefix = formula.prefix.relative_path_from(HOMEBREW_CELLAR).to_s
       binpath_re = %r{^#{prefix}/s?bin/}


### PR DESCRIPTION
I noticed when running `which-update` locally that `mosquitto` seemed to be handled differently based on whether it was checked from a bottle or from the install prefix. It turns out that the reason for this difference was that the `sbin` directory was being checked in `update_installed_formula` but not in `update_bottled_formula`. The login in `update_bottled_formula` allows for `sbin` paths to be used, but doesn't actually list any because of the pattern used for the `tar` command. This PR adds an `sbin` pattern to that `tar` command to list both `bin` and `sbin` paths to be checked for binaries.

CC @bfontaine to be sure that this is a bug and not intentional
