### PR TITLE
lib/executables_db: remove disabled formulae when updating

### DIFF
--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -53,11 +53,17 @@ module Homebrew
     # @see #save!
     def update!(update_existing: false, install_missing: false, max_downloads: nil)
       downloads = 0
+      disabled_formulae = []
       Formula.each do |f|
         break if max_downloads.present? && downloads > max_downloads.to_i
         next if f.tap?
 
         name = f.full_name
+
+        if f.disabled?
+          disabled_formulae << name
+          next
+        end
 
         update_formula = missing_formula?(f) || (update_existing && outdated_formula?(f))
 
@@ -85,7 +91,7 @@ module Homebrew
         end
       end
 
-      removed = @exes.keys - Formula.full_names
+      removed = (@exes.keys - Formula.full_names) | disabled_formulae
       removed.each do |name|
         @exes.delete name
         @changes[:remove] << name

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -32,10 +32,11 @@ module Homebrew
 
       core_percentage = ((formulae & core).size * 1000 / core.size.to_f).round / 10.0
 
+      missing = (core - formulae).reject { |f| Formula[f].disabled? }
       puts <<~EOS
         #{formulae.size} formulae
         #{cmds_count} commands
-        #{core_percentage}%  (missing: #{(core - formulae) * " "})
+        #{core_percentage}%  (missing: #{missing * " "})
       EOS
 
       unknown = formulae - Formula.full_names


### PR DESCRIPTION
Disabled formulae can't be installed so we should remove them from the database so they're not recommended to users to install.
