### PR TITLE
Replace disabled `Formula.each` call

### DIFF
--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -54,7 +54,7 @@ module Homebrew
     def update!(update_existing: false, install_missing: false, max_downloads: nil)
       downloads = 0
       disabled_formulae = []
-      Formula.each do |f|
+      Formula.all.each do |f|
         break if max_downloads.present? && downloads > max_downloads.to_i
         next if f.tap?
 


### PR DESCRIPTION
CI currently fails because `Formula.each` has been disabled. This PR updates `ExecutablesDB#update!` to use `Formula.all.each`, instead.
