### PR TITLE
Handler: ignore `-h`, `--help`, `--usage`, and `-?`

### DIFF
--- a/handler.fish
+++ b/handler.fish
@@ -1,6 +1,10 @@
 function fish_command_not_found
     set -l cmd $argv[1]
-    set -l txt (brew which-formula --explain $cmd 2> /dev/null)
+    set -l txt
+
+    if not contains -- "$cmd" "-h" "--help" "--usage" "-?"
+        set txt (brew which-formula --explain $cmd 2> /dev/null)
+    end
 
     if test -z "$txt"
         __fish_default_command_not_found_handler $cmd

--- a/handler.sh
+++ b/handler.sh
@@ -28,7 +28,9 @@ homebrew_command_not_found_handle() {
         return 127
     fi
 
-    local txt="$(brew which-formula --explain $cmd 2>/dev/null)"
+    if [ "$cmd" != "-h" ] && [ "$cmd" != "--help" ] && [ "$cmd" != "--usage" ] && [ "$cmd" != "-?" ]; then
+        local txt="$(brew which-formula --explain $cmd 2>/dev/null)"
+    fi
 
     if [ -z "$txt" ]; then
         [ -n "$BASH_VERSION" ] && \


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-command-not-found/issues/110

This PR changes the handler to simply ignore `-h`, `--help`, `--usage` and `-?` instead of passing these commands off to `brew which-formula`. These four options are the possible [help flags that are defined in `brew.rb`](https://github.com/Homebrew/brew/blob/89cf96fffac2aeb37ca4429a5afa09fe43c995e1/Library/Homebrew/brew.rb#L32), and passing them to `brew which-formula` will display the help text immediately before even getting to the execution of the `which-formula` command.
