### PR TITLE
WhichFormula: Use Ruby, not `grep`, for searching the formulae file

### DIFF
--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -9,9 +9,7 @@ module Homebrew
     module_function
 
     def matches(cmd)
-      # We use 'grep' here to speed up our search
-      # TODO: benchmark grep vs. reading the file line-by-line in Ruby
-      Utils.popen_read("grep", "--color=never", cmd, LIST_PATH).chomp.split("\n")
+      File.readlines(LIST_PATH).map(&:chomp).select { |line| line.include?(cmd) }
     end
 
     # Test if we have to reject the given formula, i.e. not suggest it.

--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -9,7 +9,7 @@ module Homebrew
     module_function
 
     def matches(cmd)
-      File.readlines(LIST_PATH).map(&:chomp).select { |line| line.include?(cmd) }
+      File.read(LIST_PATH).lines.select { |line| line.include?(cmd) }.map(&:chomp)
     end
 
     # Test if we have to reject the given formula, i.e. not suggest it.

--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -9,7 +9,7 @@ module Homebrew
     module_function
 
     def matches(cmd)
-      File.read(LIST_PATH).lines.select { |line| line.include?(cmd) }.map(&:chomp)
+      File.readlines(LIST_PATH).select { |line| line.include?(cmd) }.map(&:chomp)
     end
 
     # Test if we have to reject the given formula, i.e. not suggest it.


### PR DESCRIPTION
- I actually did the benchmarking in this TODO, with Ruby's `Benchmark`.

```
Benchmark.bm do |bm|
  bm.report(:ruby) { File.readlines(LIST_PATH).map(&:chomp).select { |line| line.include?(cmd) } }
  bm.report(:grep) { Utils.popen_read("grep", "--color=never", cmd, LIST_PATH).chomp.split("\n") }
end
```

gave the answer that:

```
❯ brew which-formula hello
       user     system      total        real
ruby  0.004031   0.000221   0.004252 (  0.004249)
grep  0.000073   0.001532   0.005908 (  0.006125)

❯ brew which-formula automysqlbackup
       user     system      total        real
ruby  0.002353   0.000284   0.002637 (  0.002651)
grep  0.000050   0.001095   0.005897 (  0.006248)
```