### PR TITLE
executables_db: avoid `Formula#all`

### DIFF
--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -20,6 +20,8 @@ module Homebrew
              description: "Update database entries with outdated formula versions."
       switch "--install-missing",
              description: "Install and update formulae that are missing from the database and don't have bottles."
+      switch "--eval-all",
+             description: "Evaluate all installed taps, rather than just the core tap."
       flag   "--max-downloads=",
              description: "Specify a maximum number of formulae to download and update."
       conflicts "--stats", "--commit"
@@ -39,7 +41,8 @@ module Homebrew
       Homebrew::WhichUpdate.update_and_save! source: args.named.first, commit: args.commit?,
                                              update_existing: args.update_existing?,
                                              install_missing: args.install_missing?,
-                                             max_downloads: args.max_downloads
+                                             max_downloads: args.max_downloads,
+                                             eval_all: args.eval_all?
     end
   end
 end

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -59,7 +59,7 @@ module Homebrew
 
       # Evaluate only the core tap by default.
       taps = eval_all ? Tap.each.to_a : [CoreTap.instance]
-      Tap.each do |tap|
+      taps.each do |tap|
         tap.formula_files_by_name.each do |name, path|
           f = Formulary.load_formula_from_path(name, path)
 

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -53,10 +53,12 @@ module Homebrew
 
     # update the DB with the installed formulae
     # @see #save!
-    def update!(update_existing: false, install_missing: false, max_downloads: nil)
+    def update!(update_existing: false, install_missing: false, max_downloads: nil, eval_all: false)
       downloads = 0
       disabled_formulae = []
 
+      # Evaluate only the core tap by default.
+      taps = eval_all ? Tap.each.to_a : [CoreTap.instance]
       Tap.each do |tap|
         tap.formula_files_by_name.each do |name, path|
           f = Formulary.load_formula_from_path(name, path)

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -45,10 +45,10 @@ module Homebrew
     end
 
     def update_and_save!(source: nil, commit: false, update_existing: false, install_missing: false,
-                         max_downloads: nil)
+                         max_downloads: nil, eval_all: false)
       source ||= default_source
       db = ExecutablesDB.new source
-      db.update!(update_existing: update_existing, install_missing: install_missing, max_downloads: max_downloads)
+      db.update!(update_existing: update_existing, install_missing: install_missing, max_downloads: max_downloads, eval_all: eval_all)
       db.save!
       return if !commit || !db.changed?
 

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -48,7 +48,8 @@ module Homebrew
                          max_downloads: nil, eval_all: false)
       source ||= default_source
       db = ExecutablesDB.new source
-      db.update!(update_existing: update_existing, install_missing: install_missing, max_downloads: max_downloads, eval_all: eval_all)
+      db.update!(update_existing: update_existing, install_missing: install_missing,
+                 max_downloads: max_downloads, eval_all: eval_all)
       db.save!
       return if !commit || !db.changed?
 


### PR DESCRIPTION
Instead, collect all formulae from their taps, then load them explicitly via `Formulary`.

This should fix #133.