### PR TITLE
Fix which-update formula loading

### DIFF
--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -60,11 +60,10 @@ module Homebrew
       # Evaluate only the core tap by default.
       taps = eval_all ? Tap.each.to_a : [CoreTap.instance]
       taps.each do |tap|
-        tap.formula_files_by_name.each do |name, path|
-          f = Formulary.load_formula_from_path(name, path)
+        tap.formula_files_by_name.each_key do |name|
+          f = Formulary.factory("#{tap}/#{name}")
 
           break if max_downloads.present? && downloads > max_downloads.to_i
-          next if f.tap?
 
           name = f.full_name
 
@@ -91,7 +90,9 @@ module Homebrew
           end
 
           # renamed formulae
-          mv f.oldname, name if !f.oldname.nil? && @exes[f.oldname]
+          f.oldnames.each do |oldname|
+            mv oldname, name if @exes[oldname]
+          end
 
           # aliased formulae
           f.aliases.each do |a|


### PR DESCRIPTION
Fixes: #137

Supercedes: #138

This PR fixes the formula loading method in `executables_db` to call the appropriate `Formulary` method. `Formulary::load_formula_from_path` only loads the formula's class into the `Formulary` namespace, but doesn't actually return an initialized formula instance. Also, this method won't work for API installs if the `homebrew/core` tap isn't installed.

Also, this should hopefully fix the CI failures that have resulted in the database not being updated in ~150 days 😅

CC: @woodruffw and @olfway
