### PR TITLE
Fix shellcheck issues in workflows

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -49,7 +49,7 @@ jobs:
           then
             MAX_DOWNLOADS_ARGS="--max-downloads ${{ github.event.inputs.max-downloads }}"
           fi
-          brew which-update --commit --update-existing --install-missing $MAX_DOWNLOADS_ARGS executables.txt
+          brew which-update --commit --update-existing --install-missing "$MAX_DOWNLOADS_ARGS" executables.txt
 
       - name: Output database stats
         working-directory: repo


### PR DESCRIPTION
`shellcheck` is reporting an SC2086 ("Double quote to prevent globbing and word splitting") issue in the `update-database.yml` workflow. This adds quotes around the related area to resolve the issue.

There are other shellcheck issues in `handler.sh` but I figured that was best left to someone who's familiar with the file and/or better at shell scripting:

```
In /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh line 12:
if ! which brew >/dev/null; then return; fi
     ^---^ SC2230 (info): 'which' is non-standard. Use builtin 'command -v' instead.


In /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh line 22:
  if test -z "${CONTINUOUS_INTEGRATION}" && test -n "${MC_SID}" -o ! -t 1
              ^-----------------------^ SC2154 (warning): CONTINUOUS_INTEGRATION is referenced but not assigned.
                                                     ^-------^ SC2154 (warning): MC_SID is referenced but not assigned.


In /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh line 27:
    [[ -n "${ZSH_VERSION}" ]] && [[ "${ZSH_VERSION}" > "5.2" ]] &&
                                                       ^---^ SC2072 (error): Decimals are not supported. Either use integers only, or use bc or awk to compare.


In /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh line 34:
    local txt="$(brew which-formula --explain "${cmd}" 2>/dev/null)"
          ^-^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In /opt/homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh line 43:
    [[ -n "${ZSH_VERSION}" ]] && [[ "${ZSH_VERSION}" > "5.2" ]] &&
                                                       ^---^ SC2072 (error): Decimals are not supported. Either use integers only, or use bc or awk to compare.

For more information:
  https://www.shellcheck.net/wiki/SC2072 -- Decimals are not supported. Eithe...
  https://www.shellcheck.net/wiki/SC2154 -- CONTINUOUS_INTEGRATION is referen...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
```

Feel free to push `handler.sh` fixes to this branch if you know how to address the issues and we want to handle this all in one PR.

Related to https://github.com/Homebrew/brew/pull/17482