### PR TITLE
brew style fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,13 @@ jobs:
 
     - name: Validate shell syntax
       run: |
+        set -xeuo pipefail
+
         bash -n handler.sh
         fish -n handler.fish
         zsh -n handler.sh
 
     - name: Run tests
-      run: |
-        export CONTINUOUS_INTEGRATION=1
-        rake test
+      run: rake test
+      env:
+        HOMEBREW_COMMAND_NOT_FOUND_CI: 1


### PR DESCRIPTION
- Fix or disable various shellcheck warnings
- Use `is-at-least` from ZSH to compare version strings properly

While we're here:
- cleanup the CI job and improve the variable name/usage

Needed for https://github.com/Homebrew/brew/pull/17482