### PR TITLE
update-database: switch to SSH signing

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
-          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+          ssh: true
+          signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -42,7 +43,6 @@ jobs:
       - name: Update database
         working-directory: repo
         env:
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           MAX_DOWNLOADS: ${{ github.event.inputs.max-downloads }}
         run: |
           set -eo pipefail


### PR DESCRIPTION
This is a good "canary" case for making sure SSH signing goes smoothly.