### PR TITLE
README.md and command-not-found-init.rb should agree on installation instructions

### DIFF
--- a/cmd/command-not-found-init.rb
+++ b/cmd/command-not-found-init.rb
@@ -45,7 +45,7 @@ module Homebrew
             # To enable homebrew-command-not-found
             # Add the following lines to ~/.#{shell}rc
 
-            HB_CNF_HANDLER="$(brew --prefix)/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
+            HB_CNF_HANDLER="$(brew --repository)/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
             if [ -f "$HB_CNF_HANDLER" ]; then
               source "$HB_CNF_HANDLER";
             fi
@@ -55,7 +55,7 @@ module Homebrew
             # To enable homebrew-command-not-found
             # Add the following line to ~/.config/fish/config.fish
 
-            set HB_CNF_HANDLER (brew --prefix)"/Homebrew/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
+            set HB_CNF_HANDLER (brew --repository)"/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
             if test -f $HB_CNF_HANDLER
               source $HB_CNF_HANDLER
             end


### PR DESCRIPTION
I had found out about [command-not-found from brew's manpage](https://docs.brew.sh/Manpage#command-not-found-init). However, the output it gave pointed to the wrong path.

Finding #68, I have replicated that change in `cmd/command-not-found-init.rb`.

