### PR TITLE
Push `executables.txt` to GitHub Packages

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -16,6 +16,8 @@ jobs:
   update-database:
     if: startsWith( github.repository, 'Homebrew/' )
     runs-on: macos-latest
+    permissions:
+      packages: write
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -59,6 +61,21 @@ jobs:
       - name: Output database stats
         working-directory: repo
         run: brew which-update --stats executables.txt
+
+      - name: Install oras for pushing to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        run: brew install oras
+
+      - name: Log in to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io --username ${{ github.actor }} --password-stdin
+
+      - name: Push to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        run: |
+          oras push --artifact-type application/vnd.homebrew.command-not-found.executables \
+            ghcr.io/homebrew/command-not-found/executables:latest \
+            executables.txt:text/plain
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@main


### PR DESCRIPTION
See #246

This PR starts to push the `executables.txt` file to GitHub packages. It does not replace the current mechanism for now.

One possible challenge with this approach is that a new item is stored each time this is updated, and the `:latest` tag is simply replaced. Do we think it's worth deleting the old artifacts after the new one has been uploaded?
