### PR TITLE
Fix GitHub Packages checksum calculation

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -80,13 +80,10 @@ jobs:
       - name: Check upload
         if: github.ref == 'refs/heads/main'
         run: |
-          sha256sum executables.txt > executables.txt.sha256
+          shasum --algorithm=256 executables.txt > executables.txt.sha256
           rm -f executables.txt
           oras pull ghcr.io/homebrew/command-not-found/executables:latest
-          if ! sha256sum --status --check executables.txt.sha256; then
-            echo "Uploaded file does not match expected checksum!"
-            exit 1
-          fi
+          shasum --algorithm=256 --check executables.txt.sha256
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@main


### PR DESCRIPTION
Since this runs on `macos-latest`, use `shasum -a 256` instead of `sha256sum`.

Also, there's no reason we need to write our own error message, so let's drop `--check` and just use the built-in one. It still errors with a non-zero exit code on checksum failure