### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-command-not-found/security/code-scanning/9](https://github.com/Homebrew/homebrew-command-not-found/security/code-scanning/9)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only installs dependencies, validates shell syntax, and runs tests, it does not require any write permissions. The most restrictive and appropriate setting is likely `contents: read`, which allows the workflow to read repository contents if needed, but not to write or modify anything. This block should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
