### PR TITLE
workflows/update-database: only set up commit signing when necessary

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -29,6 +29,7 @@ jobs:
           username: BrewTestBot
 
       - name: Set up commit signing
+        if: github.ref == 'refs/heads/main'
         uses: Homebrew/actions/setup-commit-signing@main
         with:
           ssh: true


### PR DESCRIPTION
Don't set up commit signing for e.g. Dependabot PRs.
