### PR TITLE
Enable `typed: strict`

### DIFF
--- a/cmd/command-not-found-init.rb
+++ b/cmd/command-not-found-init.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -15,6 +15,7 @@ module Homebrew
         named_args :none
       end
 
+      sig { override.void }
       def run
         if $stdout.tty?
           help
@@ -23,10 +24,12 @@ module Homebrew
         end
       end
 
+      sig { returns(T.nilable(Symbol)) }
       def shell
         Utils::Shell.parent || Utils::Shell.preferred
       end
 
+      sig { void }
       def init
         case shell
         when :bash, :zsh
@@ -38,6 +41,7 @@ module Homebrew
         end
       end
 
+      sig { void }
       def help
         case shell
         when :bash, :zsh

--- a/cmd/which-formula.rb
+++ b/cmd/which-formula.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -16,6 +16,7 @@ module Homebrew
         named_args :command, min: 1
       end
 
+      sig { override.void }
       def run
         # NOTE: It probably doesn't make sense to use that on multiple commands since
         # each one might print multiple formulae

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -31,6 +31,7 @@ module Homebrew
         named_args :database, max: 1
       end
 
+      sig { override.void }
       def run
         if args.stats?
           Homebrew::WhichUpdate.stats source: args.named.first

--- a/cmd/which-update.rb
+++ b/cmd/which-update.rb
@@ -40,7 +40,7 @@ module Homebrew
                                                  commit:          args.commit?,
                                                  update_existing: args.update_existing?,
                                                  install_missing: args.install_missing?,
-                                                 max_downloads:   args.max_downloads,
+                                                 max_downloads:   args.max_downloads&.to_i,
                                                  eval_all:        args.eval_all?
         end
       end

--- a/cmd/which-update.rbi
+++ b/cmd/which-update.rbi
@@ -21,6 +21,6 @@ class Homebrew::Cmd::WhichUpdateCmd::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def eval_all?; end
 
-  sig { params(max_downloads: T.nilable(Integer)).returns(T::Boolean) }
-  def max_downloads(max_downloads = nil); end
+  sig { returns(T.nilable(Integer)) }
+  def max_downloads; end
 end

--- a/executables.txt
+++ b/executables.txt
@@ -6968,7 +6968,7 @@ vala(0.56.18_1):vala vala-0.56 vala-gen-introspect vala-gen-introspect-0.56 vala
 vala-language-server(0.48.7):vala-language-server
 valabind(1.8.0_3):valabind valabind-cc
 vale(3.12.0):vale
-valgrind:callgrind_annotate callgrind_control cg_annotate cg_diff cg_merge ms_print valgrind valgrind-di-server valgrind-listener vgdb
+valgrind(1.0.0):callgrind_annotate callgrind_control cg_annotate cg_diff cg_merge ms_print valgrind valgrind-di-server valgrind-listener vgdb
 valijson(1.0.6):
 valkey(8.1.3):redis-benchmark redis-check-aof redis-check-rdb redis-cli redis-sentinel redis-server valkey-benchmark valkey-check-aof valkey-check-rdb valkey-cli valkey-sentinel valkey-server
 vals(0.42.0):vals

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -29,7 +29,7 @@ module Homebrew
     end
 
     class Changes
-      TYPES = %i[add remove update version_bump].freeze
+      TYPES = [:add, :remove, :update, :version_bump].freeze
 
       sig { returns(T::Set[String]) }
       attr_accessor :add, :remove, :update, :version_bump

--- a/lib/executables_db.rb
+++ b/lib/executables_db.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "formula"
@@ -12,10 +12,41 @@ module Homebrew
   class ExecutablesDB
     include Utils::Output::Mixin
 
+    sig { returns(T::Hash[String, FormulaEntry]) }
     attr_accessor :exes
+
+    sig { returns(Changes) }
     attr_reader :changes
 
-    DB_LINE_REGEX = /^(?<name>.*?)(?:\((?<version>.*)\))?:(?<exes_line>.*)?$/
+    sig { returns(Pathname) }
+    attr_reader :root
+
+    DB_LINE_REGEX = /^(?<name>.*?)(?:\((?<version>.*)\)):(?<exes_line>.*)?$/
+
+    class FormulaEntry < T::Struct
+      const :version, String
+      const :binaries, T::Array[String]
+    end
+
+    class Changes
+      TYPES = %i[add remove update version_bump].freeze
+
+      sig { returns(T::Set[String]) }
+      attr_accessor :add, :remove, :update, :version_bump
+
+      sig { void }
+      def initialize
+        @add = T.let(Set.new, T::Set[String])
+        @remove = T.let(Set.new, T::Set[String])
+        @update = T.let(Set.new, T::Set[String])
+        @version_bump = T.let(Set.new, T::Set[String])
+      end
+
+      sig { returns(T::Boolean) }
+      def changed?
+        add.any? || remove.any? || update.any? || version_bump.any?
+      end
+    end
 
     # initialize a new DB with the given filename. The file will be used to
     # populate the DB if it exists. It'll be created or overridden when saving the
@@ -24,10 +55,11 @@ module Homebrew
     sig { params(filename: String).void }
     def initialize(filename)
       @filename = filename
-      @exes = {}
+      @root = T.let(Pathname.new(@filename).parent, Pathname)
+      @exes = T.let({}, T::Hash[String, FormulaEntry])
       # keeps track of things that changed in the DB between its creation and
       # each {#save!} call. This is used to generate commit messages
-      @changes = { add: Set.new, remove: Set.new, update: Set.new, version_bump: Set.new }
+      @changes = T.let(Changes.new, Changes)
 
       return unless File.file? @filename
 
@@ -35,12 +67,11 @@ module Homebrew
         matches = line.match DB_LINE_REGEX
         next unless matches
 
-        name = matches[:name]
-        version = matches[:version]
-        exes_line = matches[:exes_line]
+        name = T.must(matches[:name])
+        version = T.must(matches[:version])
+        binaries = matches[:exes_line]&.split || []
 
-        @exes[name] ||= [version, []]
-        @exes[name][1].concat exes_line.split if exes_line.present?
+        @exes[name] ||= FormulaEntry.new(version:, binaries:)
       end
     end
 
@@ -49,14 +80,9 @@ module Homebrew
       @exes.keys
     end
 
-    sig { returns(Pathname) }
-    def root
-      @root ||= Pathname.new(@filename).parent
-    end
-
     sig { returns(T::Boolean) }
     def changed?
-      @changes.any? { |_, v| !v.empty? }
+      @changes.changed?
     end
 
     # update the DB with the installed formulae
@@ -120,7 +146,7 @@ module Homebrew
       removed = (@exes.keys - Formula.full_names) | disabled_formulae
       removed.each do |name|
         @exes.delete name
-        @changes[:remove] << name
+        @changes.remove << name
       end
       nil
     end
@@ -128,10 +154,9 @@ module Homebrew
     # save the DB in the underlying file
     sig { void }
     def save!
-      ordered_db = @exes.map do |formula, data|
-        version, exs = data
-        version_string = "(#{version})" if version.present?
-        "#{formula}#{version_string}:#{exs.join(" ")}\n"
+      ordered_db = @exes.map do |formula, entry|
+        version_string = "(#{entry.version})"
+        "#{formula}#{version_string}:#{entry.binaries.join(" ")}\n"
       end.sort
 
       File.open(@filename, "w") do |f|
@@ -145,12 +170,14 @@ module Homebrew
 
     sig { params(old: String, new: String).void }
     def mv(old, new)
+      return unless (old_entry = @exes[old])
+
       unless @exes[new]
-        @exes[new] = @exes[old]
-        @changes[:add] << new
+        @exes[new] = old_entry
+        @changes.add << new
       end
       @exes.delete old
-      @changes[:remove] << old
+      @changes.remove << old
       puts "Moving #{old} => #{new}"
     end
 
@@ -161,8 +188,9 @@ module Homebrew
 
     sig { params(formula: Formula).returns(T::Boolean) }
     def outdated_formula?(formula)
-      current_version = @exes[formula.full_name][0]
-      formula.pkg_version.to_s != current_version
+      return true unless (entry = @exes[formula.full_name])
+
+      formula.pkg_version.to_s != entry.version
     end
 
     sig { params(formula: Formula, prefix: Pathname).void }
@@ -181,18 +209,18 @@ module Homebrew
     sig { params(formula: Formula, binaries: T::Set[String]).void }
     def update_formula_binaries(formula, binaries)
       name = formula.full_name
-      version = formula.pkg_version
+      version = formula.pkg_version.to_s
       binaries = binaries.to_a.sort
 
       if missing_formula? formula
-        @changes[:add] << name
-      elsif @exes[name][1] != binaries
-        @changes[:update] << name
+        @changes.add << name
+      elsif (formula_entry = @exes[name]) && formula_entry.binaries != binaries
+        @changes.update << name
       elsif outdated_formula? formula
-        @changes[:version_bump] << name
+        @changes.version_bump << name
       end
 
-      @exes[name] = [version, binaries]
+      @exes[name] = FormulaEntry.new(version:, binaries:)
     end
 
     # update the binaries of {formula}, assuming it's installed

--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -1,19 +1,21 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "formula"
 
 module Homebrew
   module WhichFormula
-    LIST_PATH = File.expand_path("#{File.dirname(__FILE__)}/../executables.txt").freeze
+    LIST_PATH = T.let(File.expand_path("#{File.dirname(__FILE__)}/../executables.txt").freeze, String)
 
     module_function
 
+    sig { params(cmd: String).returns(T::Array[String]) }
     def matches(cmd)
       File.readlines(LIST_PATH).select { |line| line.include?(cmd) }.map(&:chomp)
     end
 
     # Test if we have to reject the given formula, i.e. not suggest it.
+    sig { params(name: String).returns(T::Boolean) }
     def reject_formula?(name)
       f = begin
         Formula[name]
@@ -25,6 +27,7 @@ module Homebrew
 
     # Output explanation of how to get 'cmd' by installing one of the providing
     # formulae.
+    sig { params(cmd: String, formulae: T::Array[String]).void }
     def explain_formulae_install(cmd, formulae)
       formulae.reject! { |f| reject_formula? f }
 
@@ -47,6 +50,7 @@ module Homebrew
     # if 'explain' is false, print all formulae that can be installed to get the
     # given command. If it's true, print them in human-readable form with an help
     # text.
+    sig { params(cmd: String, explain: T::Boolean).void }
     def which_formula(cmd, explain: false)
       cmd = cmd.downcase
 

--- a/lib/which_update.rb
+++ b/lib/which_update.rb
@@ -32,7 +32,7 @@ module Homebrew
       formulae = db.formula_names
       core = Formula.core_names
 
-      cmds_count = db.exes.values.reduce(0) { |s, exs| s + exs.size }
+      cmds_count = db.exes.values.reduce(0) { |s, exs| s + exs.binaries.size }
 
       core_percentage = ((formulae & core).size * 1000 / core.size.to_f).round / 10.0
 
@@ -79,11 +79,11 @@ module Homebrew
       "#{verb.capitalize} #{msg}"
     end
 
-    sig { params(changes: T::Hash[Symbol, T::Set[String]]).returns(String) }
+    sig { params(changes: ExecutablesDB::Changes).returns(String) }
     def git_commit_message(changes)
       msg = []
-      [:add, :update, :remove, :version_bump].each do |action|
-        names = changes.fetch(action)
+      ExecutablesDB::Changes::TYPES.each do |action|
+        names = changes.send(action)
         next if names.empty?
 
         action = "bump version for" if action == :version_bump


### PR DESCRIPTION
This will eventually be needed when this command is merged into Homebrew/brew, but we may as well start now to help with any changes needed until then.

In order to get to `typed: strict` cleanly, I needed to refactor a few things:

- I created a `FormulaEntry` struct to store formula version/binary pairs more cleanly than a tuple or array
- I created a `Changes` class to replace the hash of sets for more clean access

Either of those can be dropped if desired.

Also, for some reason there was one entry in the current database (`valgrind`) that did not yet have a version associated. This likely means that the scheduled job has never installed this formula before. To avoid needing to handle the case where there is no version, I just manually added version `1.0.0`. Since `valgrind` is currently on version `3.25.1`, this will still be marked as outdated the next time we try to install it.
