### PR TITLE
Only run `update-database` on pushes to the main branch

### DIFF
--- a/.github/workflows/update-database.yml
+++ b/.github/workflows/update-database.yml
@@ -1,6 +1,8 @@
 name: Scheduled database updates
 on:
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/update-database.yml
   pull_request:


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/homebrew-command-not-found/pull/277

If we run on all pull requests, there's no need to also run on pushes to any branch. We should restrict this to `main` branch pushes
