### PR TITLE
Fix curl no retry by set `retries = nil`

### DIFF
--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -26,7 +26,7 @@ module Homebrew
         retries = Homebrew::EnvConfig.curl_retries.to_i
       else
         max_time = 10 # seconds
-        retries = 1 # do not retry by default
+        retries = 0 # do not retry by default
       end
 
       args = Utils::Curl.curl_args(max_time:, retries:)

--- a/lib/which_formula.rb
+++ b/lib/which_formula.rb
@@ -26,7 +26,7 @@ module Homebrew
         retries = Homebrew::EnvConfig.curl_retries.to_i
       else
         max_time = 10 # seconds
-        retries = 0 # do not retry by default
+        retries = nil # do not retry by default
       end
 
       args = Utils::Curl.curl_args(max_time:, retries:)


### PR DESCRIPTION
As per the PR title, set `retries = 0` for no retry.

- This PR requires: Homebrew/brew#20722